### PR TITLE
PowerShell 5.0 has removed ContainsKey from DefaultParameterDictionary, ...

### DIFF
--- a/HistoryPx.psm1
+++ b/HistoryPx.psm1
@@ -56,7 +56,7 @@ try {
     #region Generate a warning if the output configuration variable is already configured.
 
     $parentDefaultParameterValues = Get-Variable -Name PSDefaultParameterValues -Scope 1 -ValueOnly
-    if ($parentDefaultParameterValues.ContainsKey('Out-Default:OutVariable') -and
+    if ($parentDefaultParameterValues.Contains('Out-Default:OutVariable') -and
         ($parentDefaultParameterValues['Out-Default:OutVariable'] -eq [HistoryPx.CaptureOutputConfiguration]::VariableName)) {
         Write-Warning "$([HistoryPx.CaptureOutputConfiguration]::VariableName) is currently configured as the default OutVariable parameter for Out-Default. This configuration should be removed from PSDefaultParameterValues."
     }


### PR DESCRIPTION
...using bool IDictionary.Contains(System.Object key) which is common instead.

More info:
https://msdn.microsoft.com/en-us/library/system.management.automation.defaultparameterdictionary_members(v=vs.85).aspx
https://connect.microsoft.com/PowerShell/feedback/details/1152670/global-psdefaultparametervalues-containskey-missing
